### PR TITLE
県ごとの検索

### DIFF
--- a/app/assets/stylesheets/_Flexslider.scss
+++ b/app/assets/stylesheets/_Flexslider.scss
@@ -17,11 +17,12 @@
 .flex-title {
   color: #f1f1f1;
   position: relative;
-  font-size: 5vw;
+  font-size: 3.5vw;
   margin: auto;
   text-align: center;
   transform: rotate(90deg);
   top: 15%;
+  z-index: 2;
   -webkit-transition: all 500ms ease;
   -moz-transition: all 500ms ease;
   -ms-transition: all 500ms ease;
@@ -42,8 +43,8 @@
   font-size: 2vw;
   padding: 5%;
   top: 20%;
-  border: 2px solid #f1f1f1;
-  border-radius: 10px;
+  // border: 2px solid #f1f1f1;
+  // border-radius: 10px;
   line-height: 1.3;
   margin: auto;
   text-align: left;
@@ -69,6 +70,7 @@
   -ms-flex: 1;
   /* IE 10 */
   flex: 1;
+  z-index: 1;
   cursor: pointer;
   -webkit-transition: all 500ms ease;
   -moz-transition: all 500ms ease;

--- a/app/assets/stylesheets/_prefectureFlexslider.scss
+++ b/app/assets/stylesheets/_prefectureFlexslider.scss
@@ -1,24 +1,27 @@
-.flex-container {
+.pflex-container {
   background-color: #222222;
   position: absolute;
-  height: 60vh;
+  height: 50%;
   width: 85%;
   display: -webkit-flex;
   /* Safari */
   display: flex;
   overflow: hidden;
+  flex-direction: column;
 }
 
-@media screen and (max-width: 768px) {
+// @media screen and (max-width: 768px) {
 
-.flex-container { flex-direction: column; }
-}
+// .flex-container { flex-direction: column; }
+// }
 
-.flex-title {
+.pflex-title {
   color: #f1f1f1;
   position: relative;
-  font-size: 5vw;
+  font-size: 2.5vw;
   margin: auto;
+  text-decoration: none;
+  // display: flex;
   text-align: center;
   transform: rotate(90deg);
   top: 15%;
@@ -29,19 +32,27 @@
   transition: all 500ms ease;
 }
 
-@media screen and (max-width: 768px) {
+// @media screen and (max-width: 768px) {
 
-.flex-title { transform: rotate(0deg) !important; }
+// .pflex-title { transform: rotate(0deg) !important; }
+// }
+.prefecture {
+ padding: 50px;
 }
-
-// .flex-about {
+.pflex-about {
 //   opacity: 0;
-//   color: #f1f1f1;
-//   position: relative;
-//   width: 70%;
-//   font-size: 2vw;
+  color: #f1f1f1;
+  margin-right: 15px;
+  font-size: 1vw;
 //   padding: 5%;
-//   top: 20%;
+  // top: 62%;
+  // left: -15%;
+}
+.pflex-aboutli {
+  color: #f1f1f1;
+  font-size: 1vw;
+  display: block;
+}
 //   border: 2px solid #f1f1f1;
 //   border-radius: 10px;
 //   line-height: 1.3;
@@ -55,15 +66,15 @@
 //   transition: all 500ms ease;
 // }
 
-@media screen and (max-width: 768px) {
+// @media screen and (max-width: 768px) {
 
 // .flex-about {
 //   padding: 0%;
 //   border: 0px solid #f1f1f1;
 // }
-}
+// }
 
-.flex-slide {
+.pflex-slide {
   -webkit-flex: 1;
   /* Safari 6.1+ */
   -ms-flex: 1;
@@ -77,54 +88,54 @@
   transition: all 500ms ease;
 }
 
-@media screen and (max-width: 768px) {
+// @media screen and (max-width: 768px) {
 
-.flex-slide {
-  overflow: auto;
+.pflex-slide {
+  // overflow: auto;
   overflow-x: hidden;
 }
+// }
+
+@media screen and (max-width: 768px) {
+
+.pflex-slide p { font-size: 2em; }
 }
 
 @media screen and (max-width: 768px) {
 
-.flex-slide p { font-size: 2em; }
+.pflex-slide ul li { font-size: 2em; }
 }
 
-@media screen and (max-width: 768px) {
-
-.flex-slide ul li { font-size: 2em; }
-}
-
-.flex-slide:hover {
+.pflex-slide:hover {
   -webkit-flex-grow: 3;
   flex-grow: 3;
 }
 
 .home {
-  height: 100vh;
+  height: 70vh;
   background: linear-gradient(rgba(0, 0, 0, 0.5), rgba(0, 0, 0, 0.5)), url(https://s3-us-west-2.amazonaws.com/s.cdpn.io/769286/lake-macquarie-71208_1920.jpg);
   background-size: cover;
   background-position: center center;
   // background-attachment: fixed;
 }
 
-@media screen and (min-width: 768px) {
+// @media screen and (min-width: 768px) {
 
 .home {
-  -moz-animation: aboutFlexSlide;
-  -moz-animation-duration: 3s;
-  -moz-animation-iteration-count: 1;
-  -moz-animation-delay: 0s;
-  -webkit-animation: aboutFlexSlide;
-  -webkit-animation-duration: 3s;
-  -webkit-animation-iteration-count: 1;
-  -webkit-animation-delay: 0s;
-  animation: aboutFlexSlide;
-  animation-duration: 3s;
-  animation-iteration-count: 1;
-  animation-delay: 0s;
+  // -moz-animation: aboutFlexSlide;
+  // -moz-animation-duration: 3s;
+  // -moz-animation-iteration-count: 1;
+  // -moz-animation-delay: 0s;
+  // -webkit-animation: aboutFlexSlide;
+  // -webkit-animation-duration: 3s;
+  // -webkit-animation-iteration-count: 1;
+  // -webkit-animation-delay: 0s;
+  // animation: aboutFlexSlide;
+  // animation-duration: 3s;
+  // animation-iteration-count: 1;
+  // animation-delay: 0s;
 }
-}
+// }
 
 @keyframes 
 aboutFlexSlide {  0% {
@@ -141,25 +152,25 @@ aboutFlexSlide {  0% {
 }
 }
 
-@media screen and (min-width: 768px) {
+// @media screen and (min-width: 768px) {
 
-.flex-title-home {
+.pflex-title-home {
   transform: rotate(90deg);
   top: 15%;
-  -moz-animation: homeFlextitle;
-  -moz-animation-duration: 3s;
-  -moz-animation-iteration-count: 1;
-  -moz-animation-delay: 0s;
-  -webkit-animation: homeFlextitle;
-  -webkit-animation-duration: 3s;
-  -webkit-animation-iteration-count: 1;
-  -webkit-animation-delay: 0s;
-  animation: homeFlextitle;
-  animation-duration: 3s;
-  animation-iteration-count: 1;
-  animation-delay: 0s;
+  // -moz-animation: homeFlextitle;
+  // -moz-animation-duration: 3s;
+  // -moz-animation-iteration-count: 1;
+  // -moz-animation-delay: 0s;
+  // -webkit-animation: homeFlextitle;
+  // -webkit-animation-duration: 3s;
+  // -webkit-animation-iteration-count: 1;
+  // -webkit-animation-delay: 0s;
+  // animation: homeFlextitle;
+  // animation-duration: 3s;
+  // animation-iteration-count: 1;
+  // animation-delay: 0s;
 }
-}
+// }
 
 @keyframes 
 homeFlextitle {  0% {
@@ -176,25 +187,25 @@ homeFlextitle {  0% {
 }
 }
 
-.flex-about-home { opacity: 0; }
+.pflex-about-home { opacity: 0; }
 
-@media screen and (min-width: 768px) {
+// @media screen and (min-width: 768px) {
 
-.flex-about-home {
-  -moz-animation: flexAboutHome;
-  -moz-animation-duration: 3s;
-  -moz-animation-iteration-count: 1;
-  -moz-animation-delay: 0s;
-  -webkit-animation: flexAboutHome;
-  -webkit-animation-duration: 3s;
-  -webkit-animation-iteration-count: 1;
-  -webkit-animation-delay: 0s;
-  animation: flexAboutHome;
-  animation-duration: 3s;
-  animation-iteration-count: 1;
-  animation-delay: 0s;
-}
-}
+// .flex-about-home {
+//   -moz-animation: flexAboutHome;
+//   -moz-animation-duration: 3s;
+//   -moz-animation-iteration-count: 1;
+//   -moz-animation-delay: 0s;
+//   -webkit-animation: flexAboutHome;
+//   -webkit-animation-duration: 3s;
+//   -webkit-animation-iteration-count: 1;
+//   -webkit-animation-delay: 0s;
+//   animation: flexAboutHome;
+//   animation-duration: 3s;
+//   animation-iteration-count: 1;
+//   animation-delay: 0s;
+// }
+// }
 
 @keyframes 
 flexAboutHome {  0% {

--- a/app/assets/stylesheets/modules/_index.scss
+++ b/app/assets/stylesheets/modules/_index.scss
@@ -87,14 +87,21 @@
   }
 }
 
-.CategorySection {
+.categorySection {
   display: flex;
   justify-content: center;
   background-color: #222222;
+  .categoryHeading {
+    font-size: 25px;
+    height: 100px;
+    color: #FFFFFF;
+    margin: 0 0 0 0;
+    padding: 25px 0;
+  }
 }
-.CategorySearch {
+.categorySearch {
   width: 100vw;
-  height: 700px;
+  height: 70vh;
   font-size: 25px;
   font-weight: bold;
   display: flex;
@@ -103,32 +110,36 @@
   flex-direction: column;
 }
 
-.CategoryHeading {
-  font-size: 25px;
-  height: 100px;
-  color: #FFFFFF;
-  margin: 0 0 0 0;
-  padding: 25px 0;
-}
 
 
-
-.AreaSearch {
+.prefectureSection {
   background-color: #222222;
-  height: 700px;
+  height: 200px;
   display: flex;
+  padding-top: 30px;
   justify-content: center;
   align-items: center;
   flex-direction: column;
   list-style: none;
-  &__Name {
-    font-size: 30px;
-    color: #ffffff;
-  }
-  &__Bottum {
-    font-size: 20px;
+  .prefectureHeading {
+    font-size: 25px;
+    height: 100px;
+    color: #FFFFFF;
+    margin: 0 0 0 0;
+    padding: 25px 0;
   }
 }
+.prefectureSearch {
+  width: 100vw;
+  height: 80vh;
+  font-size: 25px;
+  font-weight: bold;
+  display: flex;
+  align-items: center;
+  background-color: #222222;
+  flex-direction: column;
+}
+
 
 .PresentLocationSearch {
   background-color: #4682B4;

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -1,9 +1,12 @@
 class CategoriesController < ApplicationController
+
   def index
     category = Post.where(category_id: params[:category_id])
   end
 
   def show
+    @category = Category.find(params[:category_id])
     @categories = Post.where(category_id: params[:category_id])
   end
+
 end

--- a/app/controllers/prefectures_controller.rb
+++ b/app/controllers/prefectures_controller.rb
@@ -1,0 +1,10 @@
+class PrefecturesController < ApplicationController
+  def index
+    prefecture = Post.where(prefecture_id: params[:prefecture_id])
+  end
+
+  def show
+    @prefecture = Prefecture.find(params[:prefecture_id])
+    @prefectures = Post.where(prefecture_id: params[:prefecture_id])
+  end
+end

--- a/app/views/posts/_Flexslider.html.erb
+++ b/app/views/posts/_Flexslider.html.erb
@@ -3,10 +3,12 @@
     <%= link_to 'favorite', 'categories/index?category_id=0', class: "flex-title flex-title"%>
     <div class="flex-about flex-about-home"></div>
   </div>
-  <div class="flex-slide food">
-    <%= link_to 'food', 'categories/index?category_id=1', class: "flex-title flex-title"%>
-    <div class="flex-about flex-about-home"></div>
-  </div>
+  <%= link_to 'categories/index?category_id=1' do %>
+    <div class="flex-slide food">
+      <%= link_to 'food', 'categories/index?category_id=1', class: "flex-title flex-title"%>
+      <div class="flex-about flex-about-home"></div>
+    </div>
+  <% end %>
   <div class="flex-slide about">
     <%= link_to 'shopping', 'categories/index?category_id=2', class: "flex-title flex-title"%>
     <div class="flex-about flex-about-home"></div>

--- a/app/views/posts/_prefectureFlexslider.html.erb
+++ b/app/views/posts/_prefectureFlexslider.html.erb
@@ -1,26 +1,79 @@
-<div class="flex-container">
-  <div class="flex-slide home">
-    <%= link_to 'favorite', 'categories/index?category_id=0', class: "flex-title flex-title"%>
-    <div class="flex-about flex-about-home"><p>Click here to navigate to the home section of the website</p></div>
+<div class="pflex-container">
+  <div class="pflex-slide home">
+    <%= link_to '北海道・東北', 'categories/index?category_id=0', class: "pflex-title pflex-title"%>
+      <div class="prefecture">
+        <%= link_to '北海道', 'prefectures/index?prefecture_id=0', class: "pflex-about"%>
+        <%= link_to '青森県', 'prefectures/index?prefecture_id=1', class: "pflex-about"%>
+        <%= link_to '岩手県', 'prefectures/index?prefecture_id=2', class: "pflex-about"%>
+        <%= link_to '宮城県', 'prefectures/index?prefecture_id=3', class: "pflex-about"%>
+        <%= link_to '秋田県', 'prefectures/index?prefecture_id=4', class: "pflex-about"%>
+        <%= link_to '山形県', 'prefectures/index?prefecture_id=5', class: "pflex-about"%>
+        <%= link_to '福島県', 'prefectures/index?prefecture_id=6', class: "pflex-about"%>
+      </div>
   </div>
-  <div class="flex-slide food">
-    <%= link_to 'food', 'categories/index?category_id=1', class: "flex-title flex-title"%>
-    <div class="flex-about flex-about-home"><p>Click here to navigate to the home section of the website</p></div>
+  <div class="pflex-slide food">
+    <%= link_to '関東', '#', class: "pflex-title pflex-title"%>
+      <div class="prefecture">
+        <%= link_to '茨城県', 'prefectures/index?prefecture_id=7', class: "pflex-about"%>
+        <%= link_to '栃木県', 'prefectures/index?prefecture_id=8', class: "pflex-about"%>
+        <%= link_to '群馬県', 'prefectures/index?prefecture_id=9', class: "pflex-about"%>
+        <%= link_to '埼玉県', 'prefectures/index?prefecture_id=10', class: "pflex-about"%>
+        <%= link_to '千葉県', 'prefectures/index?prefecture_id=11', class: "pflex-about"%>
+        <%= link_to '東京都', 'prefectures/index?prefecture_id=12', class: "pflex-about"%>
+        <%= link_to '神奈川県', 'prefectures/index?prefecture_id=13', class: "pflex-about"%>
+      </div>
   </div>
-  <div class="flex-slide about">
-    <%= link_to 'shopping', 'categories/index?category_id=2', class: "flex-title flex-title"%>
-    <div class="flex-about flex-about-home"><p>Click here to navigate to the home section of the website</p></div>
+  <div class="pflex-slide about">
+    <%= link_to '中部', 'categories/index?category_id=2', class: "pflex-title pflex-title"%>
+      <div class="prefecture">
+        <%= link_to '新潟県', 'prefectures/index?prefecture_id=14', class: "pflex-about"%>
+        <%= link_to '富山県', 'prefectures/index?prefecture_id=15', class: "pflex-about"%>
+        <%= link_to '石川県', 'prefectures/index?prefecture_id=16', class: "pflex-about"%>
+        <%= link_to '福井県', 'prefectures/index?prefecture_id=17', class: "pflex-about"%>
+        <%= link_to '山梨県', 'prefectures/index?prefecture_id=18', class: "pflex-about"%>
+        <%= link_to '長野県', 'prefectures/index?prefecture_id=19', class: "pflex-about"%>
+        <%= link_to '岐阜県', 'prefectures/index?prefecture_id=20', class: "pflex-about"%>
+        <%= link_to '静岡県', 'prefectures/index?prefecture_id=21', class: "pflex-about"%>
+        <%= link_to '愛知県', 'prefectures/index?prefecture_id=22', class: "pflex-about"%>
+      </div>
   </div>
-  <div class="flex-slide work">
-    <%= link_to "nature", "categories/index?category_id=3", class: "flex-title flex-title" %>
-    <div class="flex-about flex-about-home"><p>Click here to navigate to the home section of the website</p></div>
+  <div class="pflex-slide work">
+    <%= link_to "近畿", "categories/index?category_id=3", class: "pflex-title pflex-title" %>
+      <div class="prefecture">
+        <%= link_to '三重県', 'prefectures/index?prefecture_id=23', class: "pflex-about"%>
+        <%= link_to '滋賀県', 'prefectures/index?prefecture_id=24', class: "pflex-about"%>
+        <%= link_to '京都府', 'prefectures/index?prefecture_id=25', class: "pflex-about"%>
+        <%= link_to '大阪府', 'prefectures/index?prefecture_id=26', class: "pflex-about"%>
+        <%= link_to '兵庫県', 'prefectures/index?prefecture_id=27', class: "pflex-about"%>
+        <%= link_to '奈良県', 'prefectures/index?prefecture_id=28', class: "pflex-about"%>
+        <%= link_to '和歌山県', 'prefectures/index?prefecture_id=29', class: "pflex-about"%>
+      </div>
   </div>
-  <div class="flex-slide contact">
-    <%= link_to 'event', 'categories/index?category_id=4', class: "flex-title flex-title"%>
-    <div class="flex-about flex-about-home"><p>Click here to navigate to the home section of the website</p></div>
+  <div class="pflex-slide contact">
+    <%= link_to '中国・四国', 'categories/index?category_id=4', class: "pflex-title pflex-title"%>
+      <div class="prefecture">
+        <%= link_to '鳥取県', 'prefectures/index?prefecture_id=30', class: "pflex-about"%>
+        <%= link_to '島根県', 'prefectures/index?prefecture_id=31', class: "pflex-about"%>
+        <%= link_to '岡山県', 'prefectures/index?prefecture_id=32', class: "pflex-about"%>
+        <%= link_to '広島県', 'prefectures/index?prefecture_id=33', class: "pflex-about"%>
+        <%= link_to '山口県', 'prefectures/index?prefecture_id=34', class: "pflex-about"%>
+        <%= link_to '徳島県', 'prefectures/index?prefecture_id=35', class: "pflex-about"%>
+        <%= link_to '香川県', 'prefectures/index?prefecture_id=36', class: "pflex-about"%>
+        <%= link_to '愛媛県', 'prefectures/index?prefecture_id=37', class: "pflex-about"%>
+        <%= link_to '高知県', 'prefectures/index?prefecture_id=38', class: "pflex-about"%>
+      </div>
   </div>
-  <div class="flex-slide home">
-    <%= link_to 'favorite', 'categories/index?category_id=0', class: "flex-title flex-title"%>
-    <div class="flex-about flex-about-home"><p>Click here to navigate to the home section of the website</p></div>
+  <div class="pflex-slide home">
+    <%= link_to '九州・沖縄', 'categories/index?category_id=0', class: "pflex-title pflex-title"%>
+      <div class="prefecture">
+        <%= link_to '福岡県', 'prefectures/index?prefecture_id=39', class: "pflex-about"%>
+        <%= link_to '佐賀県', 'prefectures/index?prefecture_id=40', class: "pflex-about"%>
+        <%= link_to '長崎県', 'prefectures/index?prefecture_id=41', class: "pflex-about"%>
+        <%= link_to '熊本県', 'prefectures/index?prefecture_id=42', class: "pflex-about"%>
+        <%= link_to '大分県', 'prefectures/index?prefecture_id=43', class: "pflex-about"%>
+        <%= link_to '宮崎県', 'prefectures/index?prefecture_id=44', class: "pflex-about"%>
+        <%= link_to '鹿児島県', 'prefectures/index?prefecture_id=45', class: "pflex-about"%>
+        <%= link_to '沖縄県', 'prefectures/index?prefecture_id=46', class: "pflex-about"%>
+      </div>
   </div>
 </div>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -16,18 +16,18 @@
     </div>
   </div>
 </div>
-<div class='CategorySection'>
-  <p class='CategoryHeading'>Category
+<div class='categorySection'>
+  <p class='categoryHeading'>Category
   </p>
 </div>
-<div class='CategorySearch'>
+<div class='categorySearch'>
   <%= render partial: "Flexslider" %>
 </div>
-<div class='CategorySection'>
-  <p class='CategoryHeading'> Prefecture
+<div class='prefectureSection'>
+  <p class='prefectureHeading'> Prefecture
   </p>
 </div>
-<div class='CategorySearch'>
+<div class='prefectureSearch'>
   <%= render partial: "prefectureFlexslider" %>
 </div>
 
@@ -60,7 +60,6 @@
       <div class="PostTitle">
         <span>~ <%= post.title %> ~</span>
       </div>
-      <%= link_to({:controller => "posts", :action => "show", :id => post.id}) do %>
       <div class='PostImage' style="background-image: url(<%= post.image %>);">
         <div class="AreaInfomation">
           <div class="UserIcon">
@@ -84,7 +83,6 @@
           </ul>
         </div>
       </div>
-      <% end %>
       <div class='ReviewBox'>
         <div class='ReviewBox__LikeIcon'>
           <i class="fas fa-thumbs-up"></i>

--- a/app/views/prefectures/show.html.erb
+++ b/app/views/prefectures/show.html.erb
@@ -1,10 +1,10 @@
 <div class='NewPostMessage'>
   <h2 class='NewPostMessage__heading'>
-    <%= @category.name %>
+    <%= @prefecture.name %> の投稿
   </h2>
 </div>
 <div class="PostIndex">
-  <% @categories.each do |post| %>
+  <% @prefectures.each do |post| %>
     <div class='NewPost'>
       <div class='UserInfomation'>
         <div class='UserInfomation__userImage'>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,4 +10,6 @@ Rails.application.routes.draw do
   resources :users, only: :show
 
   resources :categories, only: [:index, :show]
+
+  resources :prefectures, only: [:index, :show]
 end


### PR DESCRIPTION
# What
投稿を県別で表示するためにビュー（リンクの設置）並びにコントローラーの設定を行う。
prefecture_controllerを作成し、prefecture_idを取得できるように設定。
コントローラーの情報をビューに渡し、県別の表示が可能となる。

# Why
県別で表示することで利用者の利便性が上がるため。